### PR TITLE
Replace dexscreener with GeckoTerminal due to CG partnership

### DIFF
--- a/app/routes/pools/$poolId/analytics.tsx
+++ b/app/routes/pools/$poolId/analytics.tsx
@@ -182,11 +182,11 @@ export default function Analytics() {
           <h2 className="text-xl font-medium">Transactions</h2>
           <a
             className="flex items-center gap-1 text-right text-xs text-night-400 hover:underline"
-            href={`https://dexscreener.com/arbitrum/${pair.id}`}
+            href={`https://www.geckoterminal.com/arbitrum/pools/${pair.id}`}
             target="_blank"
             rel="noopener noreferrer"
           >
-            More on DEX Screener
+            More on GeckoTerminal
             <ExternalLinkIcon className="h-3 w-3" />
           </a>
         </div>


### PR DESCRIPTION
Please feel free to merge if approved! 😄 

Replaces links with:
- ELM/MAGIC: https://www.geckoterminal.com/arbitrum/pools/0xf904469497e6a179a9d47a7b468e4be42ec56e65
- MAGIC/GFLY: https://www.geckoterminal.com/arbitrum/pools/0x088f2bd3667f385427d9289c28725d43d4b74ab4